### PR TITLE
Add Serverless TF module example

### DIFF
--- a/serverless_tf_sample/api-lambda-dynamodb-example/README.md
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/README.md
@@ -1,0 +1,26 @@
+## Deploying the example application
+This Lambda function interacts with DynamoDB. For the example to work, it requires an existing DynamoDB table in an AWS account. Deploying this creates all the required resources for local testing and debugging of the Lambda function.
+
+To deploy:
+
+1- Initialize a working directory containing Terraform configuration files:
+```
+terraform init
+```
+2- Deploy the application using Terraform CLI. 
+```
+terraform apply -auto-approve
+```
+## Local testing
+With the backend services now deployed, run local tests to see if everything is working. The locally running sample Lambda function interacts with the services deployed in the AWS account. Run the sam build to reflect the local sam testing environment with changes after each code update.
+
+1- Local Build: To create a local build of the Lambda function for testing, use the sam build command:
+```
+sam build --hook-name terraform --beta-features
+```
+
+2- Local invoke: The first test is to invoke the Lambda function with a mocked event payload from the API Gateway. These events are in the events directory. Run this command, passing in a mocked event:
+```
+AWS_DEFAULT_REGION=<Your Region Name>
+sam local invoke module.publish_book_review.aws_lambda_function.this[0] -e events/new-review.json --beta-features
+```

--- a/serverless_tf_sample/api-lambda-dynamodb-example/events/bad-review-score.json
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/events/bad-review-score.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.0",
+    "routeKey": "POST /",
+    "rawPath": "/",
+    "rawQueryString": "",
+    "headers": {
+      "accept": "*/*",
+      "accept-encoding": "gzip, deflate, br",
+      "cache-control": "no-cache",
+      "content-length": "67",
+      "content-type": "application/json",
+      "host": "5gduqjk6dg.execute-api.ap-southeast-2.amazonaws.com",
+      "postman-token": "e1e29d9d-389f-45da-b7f3-c5bdd873c916",
+      "user-agent": "PostmanRuntime/7.26.10",
+      "x-amzn-trace-id": "Root=1-6087880a-1c8111a52205e65b2c2e5e1a",
+      "x-forwarded-for": "69.21.110.171",
+      "x-forwarded-port": "443",
+      "x-forwarded-proto": "https"
+    },
+    "requestContext": {
+      "accountId": "088xxxx489",
+      "apiId": "5gduqjk6dg",
+      "domainName": "5gduqjk6dg.execute-api.ap-southeast.amazonaws.com",
+      "domainPrefix": "5gduqjk6dg",
+      "http": {
+        "method": "POST",
+        "path": "/",
+        "protocol": "HTTP/1.1",
+        "sourceIp": "69.21.110.171",
+        "userAgent": "PostmanRuntime/7.26.10"
+      },
+      "requestId": "12345",
+      "routeKey": "POST /",
+      "stage": "$default",
+      "time": "27/Apr/2021:03:42:02 +0000",
+      "timeEpoch": 1619494922394
+    },
+    "body": "{\"BookTitle\":\"My fave book\", \"ReviewScore\": \"17\", \"ReviewText\":\"Epic read! Definitely recommended!\"}",
+    "isBase64Encoded": false
+  }

--- a/serverless_tf_sample/api-lambda-dynamodb-example/events/lambda-input.json
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/events/lambda-input.json
@@ -1,0 +1,5 @@
+{
+    "BookTitle": "My fave book",
+    "ReviewScore": "8",
+    "ReviewText": "Epic read! Definitely recommended!"
+}

--- a/serverless_tf_sample/api-lambda-dynamodb-example/events/new-review.json
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/events/new-review.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.0",
+    "routeKey": "POST /",
+    "rawPath": "/",
+    "rawQueryString": "",
+    "headers": {
+      "accept": "*/*",
+      "accept-encoding": "gzip, deflate, br",
+      "cache-control": "no-cache",
+      "content-length": "67",
+      "content-type": "application/json",
+      "host": "5gduqjk6dg.execute-api.ap-southeast-2.amazonaws.com",
+      "postman-token": "e1e29d9d-389f-45da-b7f3-c5bdd873c916",
+      "user-agent": "PostmanRuntime/7.26.10",
+      "x-amzn-trace-id": "Root=1-6087880a-1c8111a52205e65b2c2e5e1a",
+      "x-forwarded-for": "69.21.110.171",
+      "x-forwarded-port": "443",
+      "x-forwarded-proto": "https"
+    },
+    "requestContext": {
+      "accountId": "088xxxx489",
+      "apiId": "5gduqjk6dg",
+      "domainName": "5gduqjk6dg.execute-api.ap-southeast.amazonaws.com",
+      "domainPrefix": "5gduqjk6dg",
+      "http": {
+        "method": "POST",
+        "path": "/",
+        "protocol": "HTTP/1.1",
+        "sourceIp": "69.21.110.171",
+        "userAgent": "PostmanRuntime/7.26.10"
+      },
+      "requestId": "12345",
+      "routeKey": "POST /",
+      "stage": "$default",
+      "time": "27/Apr/2021:03:42:02 +0000",
+      "timeEpoch": 1619494922394
+    },
+    "body": "{\"BookTitle\":\"My fave book\", \"ReviewScore\": \"8\", \"ReviewText\":\"Epic read! Definitely recommended!\"}",
+    "isBase64Encoded": false
+  }

--- a/serverless_tf_sample/api-lambda-dynamodb-example/locals.json
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/locals.json
@@ -1,0 +1,5 @@
+{
+    "aws_lambda_function.publish_book_review": {
+        "DYNAMODB_TABLE_NAME": "GameScores2"
+    }
+}

--- a/serverless_tf_sample/api-lambda-dynamodb-example/main.tf
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/main.tf
@@ -1,0 +1,197 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.19"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "aws" {
+    region = "us-west-1"
+}
+
+module "publish_book_review" {
+  source        = "terraform-aws-modules/lambda/aws"
+  version       = "4.6.0"
+  create_role   = false 
+  timeout       = 30
+  source_path   = local.lambda_src_path
+  function_name = "publish-book-review"
+  handler       = "index.lambda_handler"
+  runtime       = "python3.8"
+  lambda_role   = aws_iam_role.iam_for_lambda.arn
+  environment_variables = {
+    DYNAMODB_TABLE_NAME = "${aws_dynamodb_table.book-reviews-ddb-table.id}"
+  }
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda_usage"
+
+  assume_role_policy = <<EOF
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+            "Service": "lambda.amazonaws.com"
+        },
+        "Effect": "Allow",
+        "Sid": ""
+        }
+    ]
+    }
+    EOF
+
+  inline_policy {
+    name = "dynamodb_access"
+
+    policy = jsonencode({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+            "Action": [
+                "dynamodb:List*",
+                "dynamodb:DescribeReservedCapacity*",
+                "dynamodb:DescribeLimits",
+                "dynamodb:DescribeTimeToLive"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+            },
+            {
+            "Action": [
+                "dynamodb:BatchGet*",
+                "dynamodb:DescribeStream",
+                "dynamodb:DescribeTable",
+                "dynamodb:Get*",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:BatchWrite*",
+                "dynamodb:CreateTable",
+                "dynamodb:Delete*",
+                "dynamodb:Update*",
+                "dynamodb:PutItem"
+            ],
+            "Resource": [
+                "${aws_dynamodb_table.book-reviews-ddb-table.arn}"
+            ],
+            "Effect": "Allow"
+            }
+        ]
+    })
+  }
+
+}
+
+resource "aws_dynamodb_table" "book-reviews-ddb-table" {
+  name           = "BookReviews"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "ReviewId"
+  range_key      = "BookTitle"
+
+  attribute {
+    name = "ReviewId"
+    type = "S"
+  }
+
+  attribute {
+    name = "BookTitle"
+    type = "S"
+  }
+
+  attribute {
+    name = "ReviewScore"
+    type = "N"
+  }
+
+  global_secondary_index {
+    name               = "BookTitleIndex"
+    hash_key           = "BookTitle"
+    range_key          = "ReviewScore"
+    write_capacity     = 1
+    read_capacity      = 1
+    projection_type    = "INCLUDE"
+    non_key_attributes = ["ReviewId"]
+  }
+
+  tags = {
+    Name        = "book-reviews-table"
+  }
+}
+
+
+## API Gateway
+
+resource "aws_apigatewayv2_api" "lambda" {
+  name          = "book_reviews_service"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_stage" "lambda" {
+  api_id = aws_apigatewayv2_api.lambda.id
+
+  name        = "serverless_lambda_stage"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_gw.arn
+
+    format = jsonencode({
+      requestId               = "$context.requestId"
+      sourceIp                = "$context.identity.sourceIp"
+      requestTime             = "$context.requestTime"
+      protocol                = "$context.protocol"
+      httpMethod              = "$context.httpMethod"
+      resourcePath            = "$context.resourcePath"
+      routeKey                = "$context.routeKey"
+      status                  = "$context.status"
+      responseLength          = "$context.responseLength"
+      integrationErrorMessage = "$context.integrationErrorMessage"
+      }
+    )
+  }
+}
+
+resource "aws_apigatewayv2_integration" "publish_book_review_api" {
+  api_id = aws_apigatewayv2_api.lambda.id
+
+  integration_uri    = module.publish_book_review.lambda_function_invoke_arn
+  integration_type   = "AWS_PROXY"
+  integration_method = "POST"
+}
+
+resource "aws_apigatewayv2_route" "publish_book_review_route" {
+  api_id = aws_apigatewayv2_api.lambda.id
+
+  route_key = "POST /book-review"
+  target    = "integrations/${aws_apigatewayv2_integration.publish_book_review_api.id}"
+}
+
+resource "aws_cloudwatch_log_group" "api_gw" {
+  name = "/aws/api_gw/${aws_apigatewayv2_api.lambda.name}"
+
+  retention_in_days = 30
+}
+
+resource "aws_lambda_permission" "api_gw" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = module.publish_book_review.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+
+  source_arn = "${aws_apigatewayv2_api.lambda.execution_arn}/*/*"
+}

--- a/serverless_tf_sample/api-lambda-dynamodb-example/outputs.tf
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/outputs.tf
@@ -1,0 +1,12 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+output "lambda_arn" {
+  description = "Deployment invoke url"
+  value       = aws_apigatewayv2_stage.lambda.invoke_url
+}
+
+output "publish_book_url" {
+  description = "Deployment invoke url"
+  value     = "${aws_apigatewayv2_stage.lambda.invoke_url}/book-review"
+}

--- a/serverless_tf_sample/api-lambda-dynamodb-example/src/index.py
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/src/index.py
@@ -1,0 +1,105 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+from operator import truediv
+import boto3
+from botocore.config import Config
+import json
+import os
+import uuid
+#import ptvsd
+
+#ptvsd.enable_attach(address=('0.0.0.0', 9999), redirect_output=True)
+#ptvsd.wait_for_attach()
+
+client = boto3.client('dynamodb')
+sts = boto3.client('sts')
+
+DYNAMODB_TABLE_NAME = os.environ.get("DYNAMODB_TABLE_NAME")
+EVENT_DATA_FIELDS = ["BookTitle", "ReviewScore"]
+
+
+def validate_event(event):
+    print(event)
+    valid_flag = True
+    msg = None
+    
+    print(event['ReviewScore'])
+    if not validate_review_score(event['ReviewScore']):
+        valid_flag = False
+        msg = "Review score is not valid"
+    
+    # Check if all data fields are present in the event
+    if not all(k in event for k in EVENT_DATA_FIELDS):
+        valid_flag = False
+        msg = "Invalid input"
+    
+    return (valid_flag, msg)
+
+
+def validate_review_score(score):
+    if 1 <= int(score) <= 10:
+        return True
+    else:
+        return False
+
+
+def save_to_ddb(ddb_payload):
+    return client.put_item(
+        TableName=DYNAMODB_TABLE_NAME,
+        Item=ddb_payload
+    )
+
+
+def lambda_handler(event, context):    
+    processed_event = json.loads(event['body'])
+    review_id = uuid.uuid4()
+    response = None
+    
+    # Check if event data is valid
+    event_validation, msg = validate_event(processed_event)
+
+    if event_validation is True:
+
+        ddb_payload = {
+            'ReviewId': {
+                'S': str(review_id)
+            },
+            'BookTitle': {
+                'S': processed_event['BookTitle']
+            },
+            'ReviewScore': {
+                'N': processed_event['ReviewScore']
+            }
+        }
+
+        if "ReviewText" in processed_event:
+            ddb_payload['ReviewText'] = {
+                'S': processed_event['ReviewText']
+            }
+
+        data = save_to_ddb(ddb_payload)
+
+        print(data)
+        data['ResponseMetadata']['HTTPStatusCode']
+        
+        response = {
+            'statusCode': 200,
+            'body': 'successfully created item!',
+            'headers': {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*'
+            },
+        }
+
+    else:
+        response = {
+            'statusCode': 400,
+            'body': msg,
+            'headers': {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*'
+            }
+        }
+    
+    return(response)

--- a/serverless_tf_sample/api-lambda-dynamodb-example/src/requirements.txt
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/src/requirements.txt
@@ -1,0 +1,2 @@
+requests
+ptvsd

--- a/serverless_tf_sample/api-lambda-dynamodb-example/variables.tf
+++ b/serverless_tf_sample/api-lambda-dynamodb-example/variables.tf
@@ -1,0 +1,8 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+locals {
+  building_path = "build"
+  lambda_code_filename = "publishBookReview.zip"
+  lambda_src_path = "./src"
+}


### PR DESCRIPTION
Added the api-lambda-dynamodb example using the serverless tf module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
