### PR TITLE
Fixes #8 (temp.) - [ERROR] Runtime.ImportModuleError: Unable to import module 'index'

### DIFF
--- a/zip_based_lambda_functions/api-lambda-dynamodb-example/src/requirements.txt
+++ b/zip_based_lambda_functions/api-lambda-dynamodb-example/src/requirements.txt
@@ -1,2 +1,3 @@
 requests
 ptvsd
+urllib3==1.26.15


### PR DESCRIPTION
Fixes #8 temporarily 

*Description of changes:*
Lock `urllib3==1.26.15`, then `terraform destroy` then `terraform apply` and it will deploy it with the correct dependency to allow the demo to work. 

![image](https://github.com/aws-samples/aws-sam-terraform-examples/assets/1504756/4445e7e6-6349-4ebe-a7d2-7919b33ada03)