### PR TITLE
Fix assume role policy

### DIFF
--- a/zip_based_lambda_functions/api-lambda-dynamodb-example/main.tf
+++ b/zip_based_lambda_functions/api-lambda-dynamodb-example/main.tf
@@ -65,7 +65,7 @@ resource "aws_iam_role" "iam_for_lambda" {
   name = "iam_for_lambda"
 
   assume_role_policy = <<EOF
-    {
+{
     "Version": "2012-10-17",
     "Statement": [
         {


### PR DESCRIPTION
Fixes whitespace error invalid json

*Issue #, if available:*
16

*Description of changes:*
Remove whitespace in assume role json to eliminate `terraform apply` error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
